### PR TITLE
Add interactive web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# MC
+# Minecraft Server Manager
+
+This repository provides utilities to manage a Minecraft server using the RCON protocol. A command line client is provided as well as a small web interface.
+
+## Features
+
+- Connect to a server via RCON
+- List online players and server status
+- Ban players
+- Broadcast messages
+- Restart the server
+- Send arbitrary commands
+- Tail the server log file
+- Simple web dashboard
+
+## Command Line Usage
+
+Enable RCON in your `server.properties` file:
+
+```
+enable-rcon=true
+rcon.port=25575
+rcon.password=<your_password>
+```
+
+Install Python 3.9+ and run the script:
+
+```
+python minecraft_manager.py --host <server-host> --password <rcon-password> <command> [options]
+```
+
+Examples:
+
+```bash
+# List players online
+python minecraft_manager.py --host 127.0.0.1 --password secret players
+
+# Broadcast a message
+python minecraft_manager.py --host 127.0.0.1 --password secret broadcast "Server maintenance soon!"
+
+# Ban a player
+python minecraft_manager.py --host 127.0.0.1 --password secret ban Notch
+
+# Show the last 50 lines of the log file
+python minecraft_manager.py --host 127.0.0.1 --password secret --log-file /path/to/latest.log logs --lines 50
+```
+
+Note: the restart command simply sends `restart` through RCON. You must have a plugin or script handling server restarts.
+
+## Web Interface
+
+A small FastAPI application provides a basic dashboard. Start it with `uvicorn`:
+
+```bash
+uvicorn web_manager:app --reload
+```
+
+On first launch it will ask for the Minecraft server directory and RCON details. It lists all folders found under `/opt` so you can easily select your server. After saving, the dashboard lets you send commands, broadcast messages, ban players, restart the server, and view the latest log entries and online players.

--- a/minecraft_manager.py
+++ b/minecraft_manager.py
@@ -1,0 +1,155 @@
+import argparse
+import os
+import socket
+import struct
+from typing import Optional
+
+# Basic RCON protocol implementation
+class RCONClient:
+    def __init__(self, host: str, port: int, password: str, timeout: float = 3.0):
+        self.host = host
+        self.port = port
+        self.password = password
+        self.timeout = timeout
+        self.sock: Optional[socket.socket] = None
+        self.request_id = 0
+
+    def connect(self):
+        self.sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        self.sock.settimeout(self.timeout)
+        if not self._login():
+            raise ConnectionError("Failed to authenticate with RCON server")
+
+    def close(self):
+        if self.sock:
+            try:
+                self.sock.close()
+            finally:
+                self.sock = None
+
+    def _send_packet(self, packet_type: int, body: str) -> int:
+        if self.sock is None:
+            raise RuntimeError("RCON socket is not connected")
+        self.request_id += 1
+        data = body.encode('utf8') + b"\x00"
+        length = len(data) + 8
+        packet = struct.pack('<iii', length - 4, self.request_id, packet_type) + data + b"\x00"
+        self.sock.sendall(packet)
+        return self.request_id
+
+    def _recv_packet(self) -> tuple[int, int, str]:
+        if self.sock is None:
+            raise RuntimeError("RCON socket is not connected")
+        raw_len = self.sock.recv(4)
+        if len(raw_len) < 4:
+            raise ConnectionError("Unexpected EOF")
+        (length,) = struct.unpack('<i', raw_len)
+        payload = b''
+        while len(payload) < length:
+            data = self.sock.recv(length - len(payload))
+            if not data:
+                raise ConnectionError("Unexpected EOF while reading packet")
+            payload += data
+        req_id, pkt_type = struct.unpack('<ii', payload[:8])
+        body = payload[8:-2].decode('utf8', errors='replace')
+        return req_id, pkt_type, body
+
+    def _login(self) -> bool:
+        self._send_packet(3, self.password)
+        req_id, pkt_type, body = self._recv_packet()
+        if req_id == -1 or pkt_type != 2:
+            return False
+        return True
+
+    def command(self, cmd: str) -> str:
+        self._send_packet(2, cmd)
+        _req_id, _pkt_type, body = self._recv_packet()
+        return body
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Basic Minecraft server manager via RCON")
+    parser.add_argument('--host', required=True, help='Server host')
+    parser.add_argument('--port', type=int, default=25575, help='RCON port (default: 25575)')
+    parser.add_argument('--password', required=True, help='RCON password')
+    parser.add_argument('--log-file', help='Path to server log file for log operations')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    subparsers.add_parser('players', help='List online players')
+    subparsers.add_parser('status', help='Get server status (uses command list)')
+
+    ban_p = subparsers.add_parser('ban', help='Ban a player')
+    ban_p.add_argument('player', help='Player name to ban')
+
+    msg_p = subparsers.add_parser('broadcast', help='Broadcast a message to all players')
+    msg_p.add_argument('message', help='Message to broadcast')
+
+    subparsers.add_parser('restart', help='Send restart command to the server')
+
+    log_p = subparsers.add_parser('logs', help='Show last lines of log file')
+    log_p.add_argument('--lines', type=int, default=20, help='Number of log lines to show')
+
+    cmd_p = subparsers.add_parser('command', help='Send raw command')
+    cmd_p.add_argument('cmd', help='Command string')
+
+    return parser.parse_args()
+
+
+def tail_log(path: str, lines: int = 20) -> str:
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    with open(path, 'rb') as f:
+        f.seek(0, os.SEEK_END)
+        end = f.tell()
+        size = 8192
+        data = b''
+        while end > 0 and lines >= 0:
+            start = max(0, end - size)
+            f.seek(start)
+            chunk = f.read(end - start)
+            data = chunk + data
+            lines -= chunk.count(b'\n')
+            end = start
+        text = data.decode('utf8', errors='replace')
+        return '\n'.join(text.splitlines()[-lines:])
+
+
+def main():
+    args = parse_args()
+    if args.command == 'logs':
+        if not args.log_file:
+            print('Log file path is required for logs command')
+            return
+        print(tail_log(args.log_file, args.lines))
+        return
+
+    manager = RCONClient(args.host, args.port, args.password)
+    manager.connect()
+    try:
+        if args.command == 'players':
+            resp = manager.command('list')
+            print(resp)
+        elif args.command == 'status':
+            resp = manager.command('list')
+            print(resp)
+        elif args.command == 'ban':
+            resp = manager.command(f'ban {args.player}')
+            print(resp)
+        elif args.command == 'broadcast':
+            resp = manager.command(f'say {args.message}')
+            print(resp)
+        elif args.command == 'restart':
+            resp = manager.command('restart')
+            print(resp)
+        elif args.command == 'command':
+            resp = manager.command(args.cmd)
+            print(resp)
+        else:
+            print('No command given. Use -h for help.')
+    finally:
+        manager.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+{% block content %}
+{% if result %}
+<p><strong>Result:</strong> {{ result }}</p>
+{% endif %}
+<form action="/command" method="post">
+    <input name="cmd" placeholder="Command" required>
+    <button type="submit">Send</button>
+</form>
+<form action="/broadcast" method="post">
+    <input name="message" placeholder="Broadcast message" required>
+    <button type="submit">Broadcast</button>
+</form>
+<form action="/ban" method="post">
+    <input name="player" placeholder="Player name" required>
+    <button type="submit">Ban</button>
+</form>
+<form action="/restart" method="post">
+    <button type="submit">Restart Server</button>
+</form>
+<h3>Online Players</h3>
+<pre>{{ players }}</pre>
+<h3>Latest Logs</h3>
+<pre>{{ logs }}</pre>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Minecraft Manager</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }
+        .container { max-width: 800px; margin: 2em auto; background: #fff; padding: 2em; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        form { margin-bottom: 1em; }
+        input, select { padding: 0.4em; margin: 0.2em 0; width: 100%; }
+        button { padding: 0.5em 1em; }
+        pre { background: #eee; padding: 1em; overflow: auto; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Minecraft Manager</h1>
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>Initial Setup</h2>
+<form method="post">
+    <label for="server_dir">Server directory:</label>
+    <select name="server_dir" id="server_dir" required>
+        {% for d in dirs %}
+        <option value="/opt/{{ d }}">{{ d }}</option>
+        {% endfor %}
+    </select>
+    <label for="host">RCON Host:</label>
+    <input name="host" id="host" required>
+    <label for="port">RCON Port:</label>
+    <input type="number" name="port" id="port" value="25575" required>
+    <label for="password">RCON Password:</label>
+    <input type="password" name="password" id="password" required>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/web_manager.py
+++ b/web_manager.py
@@ -1,0 +1,104 @@
+import json
+import os
+from typing import Optional
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from minecraft_manager import RCONClient, tail_log
+
+CONFIG_PATH = 'config.json'
+
+app = FastAPI()
+templates = Jinja2Templates(directory='templates')
+
+
+def load_config() -> Optional[dict]:
+    if os.path.exists(CONFIG_PATH):
+        with open(CONFIG_PATH, 'r') as f:
+            return json.load(f)
+    return None
+
+def save_config(cfg: dict):
+    with open(CONFIG_PATH, 'w') as f:
+        json.dump(cfg, f)
+
+
+def rcon_command(cfg: dict, cmd: str) -> str:
+    client = RCONClient(cfg['host'], cfg['port'], cfg['password'])
+    client.connect()
+    try:
+        return client.command(cmd)
+    finally:
+        client.close()
+
+
+def available_dirs(path: str = '/opt'):
+    try:
+        return [d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d))]
+    except FileNotFoundError:
+        return []
+
+
+@app.get('/', response_class=HTMLResponse)
+async def index(request: Request):
+    cfg = load_config()
+    if not cfg:
+        return RedirectResponse('/setup')
+    players = rcon_command(cfg, 'list')
+    log_file = os.path.join(cfg['server_dir'], 'logs/latest.log')
+    logs = tail_log(log_file, 20) if os.path.exists(log_file) else 'No logs found.'
+    return templates.TemplateResponse('dashboard.html', {
+        'request': request,
+        'players': players,
+        'logs': logs,
+        'result': None,
+    })
+
+
+@app.get('/setup', response_class=HTMLResponse)
+async def setup_form(request: Request):
+    if load_config():
+        return RedirectResponse('/')
+    dirs = available_dirs('/opt')
+    return templates.TemplateResponse('setup.html', {'request': request, 'dirs': dirs})
+
+
+@app.post('/setup', response_class=HTMLResponse)
+async def setup(request: Request, server_dir: str = Form(...), host: str = Form(...), port: int = Form(...), password: str = Form(...)):
+    save_config({'server_dir': server_dir, 'host': host, 'port': port, 'password': password})
+    return RedirectResponse('/', status_code=303)
+
+
+@app.post('/command', response_class=HTMLResponse)
+async def command(request: Request, cmd: str = Form(...)):
+    cfg = load_config()
+    if not cfg:
+        return RedirectResponse('/setup')
+    result = rcon_command(cfg, cmd)
+    players = rcon_command(cfg, 'list')
+    log_file = os.path.join(cfg['server_dir'], 'logs/latest.log')
+    logs = tail_log(log_file, 20) if os.path.exists(log_file) else 'No logs found.'
+    return templates.TemplateResponse('dashboard.html', {
+        'request': request,
+        'players': players,
+        'logs': logs,
+        'result': result,
+    })
+
+
+@app.post('/broadcast', response_class=HTMLResponse)
+async def broadcast(request: Request, message: str = Form(...)):
+    return await command(request, cmd=f'say {message}')
+
+
+@app.post('/ban', response_class=HTMLResponse)
+async def ban(request: Request, player: str = Form(...)):
+    return await command(request, cmd=f'ban {player}')
+
+
+@app.post('/restart', response_class=HTMLResponse)
+async def restart(request: Request):
+    return await command(request, cmd='restart')
+


### PR DESCRIPTION
## Summary
- add FastAPI-based web interface for server management
- provide HTML templates for setup and dashboard
- list `/opt` directories during setup
- document new web dashboard in README

## Testing
- `python -m py_compile minecraft_manager.py web_manager.py`
