### PR TITLE
Add FastAPI dashboard for server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# MC
+# Minecraft Server Manager
+
+This repository provides a simple command line utility to manage a Minecraft server using the RCON protocol.
+
+## Features
+
+- Connect to a server via RCON
+- List online players and server status
+- Ban players
+- Broadcast messages
+- Restart the server
+- Send arbitrary commands
+- Tail the server log file
+
+## Usage
+
+Enable RCON in your `server.properties` file:
+
+```
+enable-rcon=true
+rcon.port=25575
+rcon.password=<your_password>
+```
+
+Install Python 3.9+ and run the script:
+
+```
+python minecraft_manager.py --host <server-host> --password <rcon-password> <command> [options]
+```
+
+Examples:
+
+```bash
+# List players online
+python minecraft_manager.py --host 127.0.0.1 --password secret players
+
+# Broadcast a message
+python minecraft_manager.py --host 127.0.0.1 --password secret broadcast "Server maintenance soon!"
+
+# Ban a player
+python minecraft_manager.py --host 127.0.0.1 --password secret ban Notch
+
+# Show the last 50 lines of the log file
+python minecraft_manager.py --host 127.0.0.1 --password secret --log-file /path/to/latest.log logs --lines 50
+```
+
+Note: the restart command simply sends `restart` through RCON. You must have a plugin or script handling server restarts.
+
+
+## Web Interface
+
+A simple web dashboard is available using FastAPI. Start it with:
+
+```bash
+uvicorn web_manager:app --reload
+```
+
+When first opened, the page prompts for your server directory and RCON details. Directories under `/opt` are listed to help locate the server folder. After saving the configuration you can send commands, broadcast messages, ban players, restart the server and see the latest log lines.
+

--- a/minecraft_manager.py
+++ b/minecraft_manager.py
@@ -1,0 +1,155 @@
+import argparse
+import os
+import socket
+import struct
+from typing import Optional
+
+# Basic RCON protocol implementation
+class RCONClient:
+    def __init__(self, host: str, port: int, password: str, timeout: float = 3.0):
+        self.host = host
+        self.port = port
+        self.password = password
+        self.timeout = timeout
+        self.sock: Optional[socket.socket] = None
+        self.request_id = 0
+
+    def connect(self):
+        self.sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        self.sock.settimeout(self.timeout)
+        if not self._login():
+            raise ConnectionError("Failed to authenticate with RCON server")
+
+    def close(self):
+        if self.sock:
+            try:
+                self.sock.close()
+            finally:
+                self.sock = None
+
+    def _send_packet(self, packet_type: int, body: str) -> int:
+        if self.sock is None:
+            raise RuntimeError("RCON socket is not connected")
+        self.request_id += 1
+        data = body.encode('utf8') + b"\x00"
+        length = len(data) + 8
+        packet = struct.pack('<iii', length - 4, self.request_id, packet_type) + data + b"\x00"
+        self.sock.sendall(packet)
+        return self.request_id
+
+    def _recv_packet(self) -> tuple[int, int, str]:
+        if self.sock is None:
+            raise RuntimeError("RCON socket is not connected")
+        raw_len = self.sock.recv(4)
+        if len(raw_len) < 4:
+            raise ConnectionError("Unexpected EOF")
+        (length,) = struct.unpack('<i', raw_len)
+        payload = b''
+        while len(payload) < length:
+            data = self.sock.recv(length - len(payload))
+            if not data:
+                raise ConnectionError("Unexpected EOF while reading packet")
+            payload += data
+        req_id, pkt_type = struct.unpack('<ii', payload[:8])
+        body = payload[8:-2].decode('utf8', errors='replace')
+        return req_id, pkt_type, body
+
+    def _login(self) -> bool:
+        self._send_packet(3, self.password)
+        req_id, pkt_type, body = self._recv_packet()
+        if req_id == -1 or pkt_type != 2:
+            return False
+        return True
+
+    def command(self, cmd: str) -> str:
+        self._send_packet(2, cmd)
+        _req_id, _pkt_type, body = self._recv_packet()
+        return body
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Basic Minecraft server manager via RCON")
+    parser.add_argument('--host', required=True, help='Server host')
+    parser.add_argument('--port', type=int, default=25575, help='RCON port (default: 25575)')
+    parser.add_argument('--password', required=True, help='RCON password')
+    parser.add_argument('--log-file', help='Path to server log file for log operations')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    subparsers.add_parser('players', help='List online players')
+    subparsers.add_parser('status', help='Get server status (uses command list)')
+
+    ban_p = subparsers.add_parser('ban', help='Ban a player')
+    ban_p.add_argument('player', help='Player name to ban')
+
+    msg_p = subparsers.add_parser('broadcast', help='Broadcast a message to all players')
+    msg_p.add_argument('message', help='Message to broadcast')
+
+    subparsers.add_parser('restart', help='Send restart command to the server')
+
+    log_p = subparsers.add_parser('logs', help='Show last lines of log file')
+    log_p.add_argument('--lines', type=int, default=20, help='Number of log lines to show')
+
+    cmd_p = subparsers.add_parser('command', help='Send raw command')
+    cmd_p.add_argument('cmd', help='Command string')
+
+    return parser.parse_args()
+
+
+def tail_log(path: str, lines: int = 20) -> str:
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    with open(path, 'rb') as f:
+        f.seek(0, os.SEEK_END)
+        end = f.tell()
+        size = 8192
+        data = b''
+        while end > 0 and lines >= 0:
+            start = max(0, end - size)
+            f.seek(start)
+            chunk = f.read(end - start)
+            data = chunk + data
+            lines -= chunk.count(b'\n')
+            end = start
+        text = data.decode('utf8', errors='replace')
+        return '\n'.join(text.splitlines()[-lines:])
+
+
+def main():
+    args = parse_args()
+    if args.command == 'logs':
+        if not args.log_file:
+            print('Log file path is required for logs command')
+            return
+        print(tail_log(args.log_file, args.lines))
+        return
+
+    manager = RCONClient(args.host, args.port, args.password)
+    manager.connect()
+    try:
+        if args.command == 'players':
+            resp = manager.command('list')
+            print(resp)
+        elif args.command == 'status':
+            resp = manager.command('list')
+            print(resp)
+        elif args.command == 'ban':
+            resp = manager.command(f'ban {args.player}')
+            print(resp)
+        elif args.command == 'broadcast':
+            resp = manager.command(f'say {args.message}')
+            print(resp)
+        elif args.command == 'restart':
+            resp = manager.command('restart')
+            print(resp)
+        elif args.command == 'command':
+            resp = manager.command(args.cmd)
+            print(resp)
+        else:
+            print('No command given. Use -h for help.')
+    finally:
+        manager.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,29 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>Dashboard</h2>
+<p><strong>Server:</strong> {{ config.server_dir }}</p>
+<form method="post" action="/command">
+    <label>Command:</label>
+    <input type="text" name="cmd" style="width:60%">
+    <button type="submit">Send</button>
+</form>
+<form method="post" action="/broadcast">
+    <label>Broadcast:</label>
+    <input type="text" name="message" style="width:60%">
+    <button type="submit">Send</button>
+</form>
+<form method="post" action="/ban">
+    <label>Ban player:</label>
+    <input type="text" name="player">
+    <button type="submit">Ban</button>
+</form>
+<form method="post" action="/restart">
+    <button type="submit">Restart Server</button>
+</form>
+<h3>Last Log Lines</h3>
+<pre>{{ log }}</pre>
+{% if response %}
+<h3>Response</h3>
+<pre>{{ response }}</pre>
+{% endif %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Minecraft Manager</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        form { margin-bottom: 1.5em; }
+        input[type=text], input[type=password], select { width: 300px; padding: 0.4em; }
+        pre { background: #eee; padding: 1em; }
+    </style>
+</head>
+<body>
+<h1>Minecraft Manager</h1>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>Initial Setup</h2>
+<form method="post" action="/setup">
+    <label>Server Directory:</label>
+    <select name="server_dir">
+        {% for d in folders %}
+        <option value="/opt/{{ d }}">{{ d }}</option>
+        {% endfor %}
+    </select><br>
+    <label>RCON Host:</label>
+    <input type="text" name="host" value="127.0.0.1"><br>
+    <label>RCON Port:</label>
+    <input type="number" name="port" value="25575"><br>
+    <label>RCON Password:</label>
+    <input type="password" name="password"><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/web_manager.py
+++ b/web_manager.py
@@ -1,0 +1,116 @@
+import json
+import os
+from typing import Optional
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from minecraft_manager import RCONClient, tail_log
+
+CONFIG_FILE = "web_config.json"
+TEMPLATES_DIR = "templates"
+
+app = FastAPI()
+templates = Jinja2Templates(directory=TEMPLATES_DIR)
+
+
+def load_config() -> Optional[dict]:
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf8") as f:
+            return json.load(f)
+    return None
+
+
+def save_config(data: dict) -> None:
+    with open(CONFIG_FILE, "w", encoding="utf8") as f:
+        json.dump(data, f)
+
+
+def rcon_client() -> RCONClient:
+    conf = load_config()
+    if conf is None:
+        raise RuntimeError("Server not configured")
+    client = RCONClient(conf["host"], conf["port"], conf["password"])
+    client.connect()
+    return client
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    config = load_config()
+    if not config:
+        folders = [d for d in os.listdir("/opt") if os.path.isdir(os.path.join("/opt", d))]
+        return templates.TemplateResponse("setup.html", {"request": request, "folders": folders})
+    log_file = os.path.join(config["server_dir"], "logs", "latest.log")
+    log = ""
+    if os.path.exists(log_file):
+        log = tail_log(log_file, 20)
+    return templates.TemplateResponse("dashboard.html", {"request": request, "config": config, "log": log, "response": None})
+
+
+@app.post("/setup")
+async def setup(server_dir: str = Form(...), host: str = Form(...), port: int = Form(...), password: str = Form(...)):
+    save_config({"server_dir": server_dir, "host": host, "port": port, "password": password})
+    return RedirectResponse("/", status_code=303)
+
+
+@app.post("/command", response_class=HTMLResponse)
+async def send_command(request: Request, cmd: str = Form(...)):
+    resp = ""
+    try:
+        client = rcon_client()
+        resp = client.command(cmd)
+    finally:
+        if 'client' in locals():
+            client.close()
+    config = load_config()
+    log_file = os.path.join(config["server_dir"], "logs", "latest.log")
+    log = tail_log(log_file, 20) if os.path.exists(log_file) else ""
+    return templates.TemplateResponse("dashboard.html", {"request": request, "config": config, "log": log, "response": resp})
+
+
+@app.post("/broadcast", response_class=HTMLResponse)
+async def broadcast(request: Request, message: str = Form(...)):
+    resp = ""
+    try:
+        client = rcon_client()
+        resp = client.command(f"say {message}")
+    finally:
+        if 'client' in locals():
+            client.close()
+    config = load_config()
+    log_file = os.path.join(config["server_dir"], "logs", "latest.log")
+    log = tail_log(log_file, 20) if os.path.exists(log_file) else ""
+    return templates.TemplateResponse("dashboard.html", {"request": request, "config": config, "log": log, "response": resp})
+
+
+@app.post("/ban", response_class=HTMLResponse)
+async def ban(request: Request, player: str = Form(...)):
+    resp = ""
+    try:
+        client = rcon_client()
+        resp = client.command(f"ban {player}")
+    finally:
+        if 'client' in locals():
+            client.close()
+    config = load_config()
+    log_file = os.path.join(config["server_dir"], "logs", "latest.log")
+    log = tail_log(log_file, 20) if os.path.exists(log_file) else ""
+    return templates.TemplateResponse("dashboard.html", {"request": request, "config": config, "log": log, "response": resp})
+
+
+@app.post("/restart", response_class=HTMLResponse)
+async def restart(request: Request):
+    resp = ""
+    try:
+        client = rcon_client()
+        resp = client.command("restart")
+    finally:
+        if 'client' in locals():
+            client.close()
+    config = load_config()
+    log_file = os.path.join(config["server_dir"], "logs", "latest.log")
+    log = tail_log(log_file, 20) if os.path.exists(log_file) else ""
+    return templates.TemplateResponse("dashboard.html", {"request": request, "config": config, "log": log, "response": resp})
+


### PR DESCRIPTION
## Summary
- create FastAPI web dashboard with setup and command routes
- add HTML templates for setup and dashboard pages
- document starting the web interface in the README

## Testing
- `python -m py_compile minecraft_manager.py web_manager.py`
