### PR TITLE
Fix NameError in web_manager

### DIFF
--- a/web_manager.py
+++ b/web_manager.py
@@ -10,7 +10,6 @@ from minecraft_manager import RCONClient, tail_log
 CONFIG_PATH = 'server_config.json'
 
 app = FastAPI(title="Minecraft Web Manager")
-main
 
 
 def load_config() -> Optional[dict]:
@@ -177,4 +176,3 @@ async def command(cmd: str = Form(...)):
     finally:
         client.close()
     return HTMLResponse(f"<pre>{resp}</pre><p><a href='/'>Back</a></p>")
-main


### PR DESCRIPTION
## Summary
- remove stray `main` identifiers in `web_manager.py`

## Testing
- `python -m py_compile web_manager.py`