### PR TITLE
Add dashboard layout and whitelist management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Restart the server
 - Send arbitrary commands
 - Tail the server log file
+- Manage the server whitelist
 
 
 Enable RCON in your `server.properties` file:
@@ -44,4 +45,16 @@ python minecraft_manager.py --host 127.0.0.1 --password secret --log-file /path/
 ```
 
 Note: the restart command simply sends `restart` through RCON. You must have a plugin or script handling server restarts.
+
+## Web Interface
+
+Run the FastAPI app with `uvicorn`:
+
+```bash
+uvicorn web_manager:app --host 0.0.0.0 --port 8000
+```
+
+On first launch you will be asked for the server directory and RCON details.
+The dashboard then allows you to send commands, broadcast messages, ban or
+whitelist players, restart the server and view recent log entries.
 

--- a/web_manager.py
+++ b/web_manager.py
@@ -5,63 +5,128 @@ from typing import Optional
 from fastapi import FastAPI, Form
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+
+def html_page(title: str, body: str) -> HTMLResponse:
+    """Return a basic HTML page with simple styling."""
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>{title}</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }}
+            .container {{ max-width: 800px; margin: 2em auto; background: #fff; padding: 2em; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }}
+            form {{ margin-bottom: 1em; }}
+            input, select {{ padding: 0.4em; margin: 0.2em 0; width: 100%; }}
+            button {{ padding: 0.5em 1em; }}
+            pre {{ background: #eee; padding: 1em; overflow: auto; }}
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            {body}
+        </div>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)
+
 from minecraft_manager import RCONClient, tail_log
 
 CONFIG_PATH = 'server_config.json'
 
 app = FastAPI(title="Minecraft Web Manager")
-main
 
 
 def load_config() -> Optional[dict]:
     if os.path.exists(CONFIG_PATH):
-
-        with open(CONFIG_PATH, 'r', encoding='utf8') as f:
+        with open(CONFIG_PATH, "r", encoding="utf8") as f:
             return json.load(f)
     return None
 
 
 def save_config(data: dict) -> None:
-    with open(CONFIG_PATH, 'w', encoding='utf8') as f:
+    with open(CONFIG_PATH, "w", encoding="utf8") as f:
         json.dump(data, f, indent=2)
 
 
+def render_setup() -> HTMLResponse:
+    body = """
+    <h2>Setup Server Connection</h2>
+    <form method='post' action='/setup'>
+      <label>Server folder path:<input type='text' name='path'></label><br>
+      <label>RCON host:<input type='text' name='host' value='127.0.0.1'></label><br>
+      <label>RCON port:<input type='number' name='port' value='25575'></label><br>
+      <label>RCON password:<input type='password' name='password'></label><br>
+      <button type='submit'>Save</button>
+    </form>
+    """
+    return html_page("Setup", body)
+
+
+def render_dashboard(result: Optional[str] = None) -> HTMLResponse:
+    client = get_client()
+    try:
+        players = client.command("list")
+    finally:
+        client.close()
+
+    cfg = load_config()
+    log_text = ""
+    if cfg:
+        log_path = os.path.join(cfg["path"], "logs", "latest.log")
+        try:
+            log_text = tail_log(log_path, 20)
+        except FileNotFoundError:
+            log_text = f"Log file not found: {log_path}"
+
+    msg = f"<p><strong>Result:</strong> {result}</p>" if result else ""
+    body = f"""
+    {msg}
+    <form action='/command' method='post'>
+      <input name='cmd' placeholder='Command'>
+      <button type='submit'>Send</button>
+    </form>
+    <form action='/broadcast' method='post'>
+      <input name='message' placeholder='Broadcast message'>
+      <button type='submit'>Broadcast</button>
+    </form>
+    <form action='/ban' method='post'>
+      <input name='player' placeholder='Player name'>
+      <button type='submit'>Ban</button>
+    </form>
+    <form action='/whitelist' method='post'>
+      <input name='player' placeholder='Whitelist player'>
+      <select name='action'>
+        <option value='add'>Add</option>
+        <option value='remove'>Remove</option>
+      </select>
+      <button type='submit'>Update</button>
+    </form>
+    <form action='/restart' method='post'>
+      <button type='submit'>Restart Server</button>
+    </form>
+    <h3>Online Players</h3>
+    <pre>{players}</pre>
+    <h3>Latest Logs</h3>
+    <pre>{log_text}</pre>
+    """
+    return html_page("Dashboard", body)
+
+
 @app.get('/', response_class=HTMLResponse)
-async def index():
+async def index(result: str | None = None):
+    """Main entry point showing setup or dashboard."""
     cfg = load_config()
     if not cfg:
-        return HTMLResponse(
-            """
-            <h1>Setup Server Connection</h1>
-            <form method='post' action='/setup'>
-              <label>Server folder path: <input type='text' name='path'></label><br>
-              <label>RCON host: <input type='text' name='host' value='127.0.0.1'></label><br>
-              <label>RCON port: <input type='number' name='port' value='25575'></label><br>
-              <label>RCON password: <input type='password' name='password'></label><br>
-              <button type='submit'>Save</button>
-            </form>
-            """
-        )
-
-    return HTMLResponse(
-        """
-        <h1>Minecraft Server Manager</h1>
-        <ul>
-          <li><a href='/players'>Players Online</a></li>
-          <li><a href='/broadcast'>Broadcast Message</a></li>
-          <li><a href='/ban'>Ban Player</a></li>
-          <li><a href='/restart'>Restart Server</a></li>
-          <li><a href='/logs'>View Logs</a></li>
-          <li><a href='/command'>Send Command</a></li>
-        </ul>
-        """
-    )
+        return render_setup()
+    return render_dashboard(result)
 
 
 @app.post('/setup')
 async def setup(path: str = Form(...), host: str = Form(...), port: int = Form(...), password: str = Form(...)):
     save_config({"path": path, "host": host, "port": port, "password": password})
-    return RedirectResponse('/', status_code=302)
+    return render_dashboard("Configuration saved")
 
 
 def get_client() -> RCONClient:
@@ -80,21 +145,21 @@ async def players():
         resp = client.command('list')
     finally:
         client.close()
-    return HTMLResponse(f"<pre>{resp}</pre><p><a href='/'>Back</a></p>")
+    body = f"<pre>{resp}</pre><p><a href='/'>Back</a></p>"
+    return html_page('Players', body)
 
 
 @app.get('/broadcast', response_class=HTMLResponse)
 async def broadcast_form():
-    return HTMLResponse(
-        """
-        <h1>Broadcast Message</h1>
-        <form method='post'>
-          <input type='text' name='message' placeholder='Message'>
-          <button type='submit'>Send</button>
-        </form>
-        <p><a href='/'>Back</a></p>
-        """
+    body = (
+        "<h1>Broadcast Message</h1>"
+        "<form method='post'>"
+        "  <input type='text' name='message' placeholder='Message'>"
+        "  <button type='submit'>Send</button>"
+        "</form>"
+        "<p><a href='/'>Back</a></p>"
     )
+    return html_page('Broadcast', body)
 
 
 @app.post('/broadcast', response_class=HTMLResponse)
@@ -104,21 +169,20 @@ async def broadcast(message: str = Form(...)):
         resp = client.command(f'say {message}')
     finally:
         client.close()
-    return HTMLResponse(f"<pre>{resp}</pre><p><a href='/'>Back</a></p>")
+    return render_dashboard(resp)
 
 
 @app.get('/ban', response_class=HTMLResponse)
 async def ban_form():
-    return HTMLResponse(
-        """
-        <h1>Ban Player</h1>
-        <form method='post'>
-          <input type='text' name='player' placeholder='Player name'>
-          <button type='submit'>Ban</button>
-        </form>
-        <p><a href='/'>Back</a></p>
-        """
+    body = (
+        "<h1>Ban Player</h1>"
+        "<form method='post'>"
+        "  <input type='text' name='player' placeholder='Player name'>"
+        "  <button type='submit'>Ban</button>"
+        "</form>"
+        "<p><a href='/'>Back</a></p>"
     )
+    return html_page('Ban Player', body)
 
 
 @app.post('/ban', response_class=HTMLResponse)
@@ -128,45 +192,44 @@ async def ban(player: str = Form(...)):
         resp = client.command(f'ban {player}')
     finally:
         client.close()
-    return HTMLResponse(f"<pre>{resp}</pre><p><a href='/'>Back</a></p>")
+    return render_dashboard(resp)
 
 
-@app.get('/restart', response_class=HTMLResponse)
+@app.post('/restart', response_class=HTMLResponse)
 async def restart():
     client = get_client()
     try:
         resp = client.command('restart')
     finally:
         client.close()
-    return HTMLResponse(f"<pre>{resp}</pre><p><a href='/'>Back</a></p>")
+    return render_dashboard(resp)
 
 
 @app.get('/logs', response_class=HTMLResponse)
 async def logs(lines: int = 50):
     cfg = load_config()
     if not cfg:
-        return RedirectResponse('/', status_code=302)
+        return render_setup()
     log_path = os.path.join(cfg['path'], 'logs', 'latest.log')
     try:
         text = tail_log(log_path, lines)
     except FileNotFoundError:
         text = f'Log file not found: {log_path}'
-    html = f"<pre>{text}</pre><p><a href='/'>Back</a></p>"
-    return HTMLResponse(html)
+    body = f"<pre>{text}</pre><p><a href='/'>Back</a></p>"
+    return html_page('Logs', body)
 
 
 @app.get('/command', response_class=HTMLResponse)
 async def command_form():
-    return HTMLResponse(
-        """
-        <h1>Send Command</h1>
-        <form method='post'>
-          <input type='text' name='cmd' placeholder='Command'>
-          <button type='submit'>Send</button>
-        </form>
-        <p><a href='/'>Back</a></p>
-        """
+    body = (
+        "<h1>Send Command</h1>"
+        "<form method='post'>"
+        "  <input type='text' name='cmd' placeholder='Command'>"
+        "  <button type='submit'>Send</button>"
+        "</form>"
+        "<p><a href='/'>Back</a></p>"
     )
+    return html_page('Command', body)
 
 
 @app.post('/command', response_class=HTMLResponse)
@@ -176,5 +239,14 @@ async def command(cmd: str = Form(...)):
         resp = client.command(cmd)
     finally:
         client.close()
-    return HTMLResponse(f"<pre>{resp}</pre><p><a href='/'>Back</a></p>")
-main
+    return render_dashboard(resp)
+
+
+@app.post('/whitelist', response_class=HTMLResponse)
+async def whitelist(player: str = Form(...), action: str = Form('add')):
+    client = get_client()
+    try:
+        resp = client.command(f'whitelist {action} {player}')
+    finally:
+        client.close()
+    return render_dashboard(resp)


### PR DESCRIPTION
## Summary
- polish the FastAPI dashboard with a shared layout
- display players and logs on the dashboard
- allow managing the server whitelist
- update README with web interface details

## Testing
- `python -m py_compile web_manager.py`
- `python -m py_compile minecraft_manager.py`
