### PR TITLE
Update tail_log logic and add tests

### DIFF
--- a/minecraft_manager.py
+++ b/minecraft_manager.py
@@ -100,22 +100,33 @@ def parse_args():
 
 
 def tail_log(path: str, lines: int = 20) -> str:
+    """Return the last ``lines`` lines from ``path``.
+
+    The function reads the file from the end in blocks so it can efficiently
+    return the requested number of lines even for large log files.
+    """
     if not os.path.exists(path):
         raise FileNotFoundError(path)
-    with open(path, 'rb') as f:
+
+    target_lines = max(0, lines)
+    remaining_lines = target_lines
+
+    with open(path, "rb") as f:
         f.seek(0, os.SEEK_END)
         end = f.tell()
-        size = 8192
-        data = b''
-        while end > 0 and lines >= 0:
-            start = max(0, end - size)
+        block_size = 8192
+        data = b""
+
+        while end > 0 and remaining_lines > 0:
+            start = max(0, end - block_size)
             f.seek(start)
             chunk = f.read(end - start)
             data = chunk + data
-            lines -= chunk.count(b'\n')
+            remaining_lines -= chunk.count(b"\n")
             end = start
-        text = data.decode('utf8', errors='replace')
-        return '\n'.join(text.splitlines()[-lines:])
+
+        text = data.decode("utf8", errors="replace")
+        return "\n".join(text.splitlines()[-target_lines:])
 
 
 def main():

--- a/tests/test_tail_log.py
+++ b/tests/test_tail_log.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from minecraft_manager import tail_log
+
+
+def create_temp_log(lines):
+    fp = tempfile.NamedTemporaryFile(delete=False)
+    for line in lines:
+        fp.write((line + "\n").encode())
+    fp.close()
+    return fp.name
+
+
+def test_tail_log_default():
+    lines = [f"line {i}" for i in range(1, 41)]
+    path = create_temp_log(lines)
+    try:
+        result = tail_log(path)
+        assert result.splitlines() == lines[-20:]
+    finally:
+        os.unlink(path)
+
+
+def test_tail_log_custom_values():
+    lines = [f"entry {i}" for i in range(30)]
+    path = create_temp_log(lines)
+    try:
+        assert tail_log(path, 10).splitlines() == lines[-10:]
+        assert tail_log(path, 1).splitlines() == lines[-1:]
+        assert tail_log(path, 0) == ""
+    finally:
+        os.unlink(path)
+
+
+def test_tail_log_more_than_file():
+    lines = ["a", "b", "c"]
+    path = create_temp_log(lines)
+    try:
+        assert tail_log(path, 10).splitlines() == lines
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
## Summary
- fix tail_log counting logic to avoid returning too many lines
- preserve requested number of lines in a variable and decrement remaining_lines
- add new unit tests for different line counts

## Testing
- `pytest -q`