### PR TITLE
Add WebSocket log streaming

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -29,6 +29,14 @@
 <h3>Online Players</h3>
 <pre>{{ players }}</pre>
 <h3>Latest Logs</h3>
-<pre>{{ logs }}</pre>
+<pre id="log-output">{{ logs }}</pre>
+<script>
+const logBox = document.getElementById('log-output');
+const ws = new WebSocket(`ws://${location.host}/ws/logs`);
+ws.onmessage = (event) => {
+    logBox.textContent += '\n' + event.data;
+    logBox.scrollTop = logBox.scrollHeight;
+};
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- stream log file updates via `/ws/logs`
- update dashboard page to append log lines in real time

## Testing
- `python -m py_compile web_manager.py minecraft_manager.py`
- `uvicorn web_manager:app --port 8000 --host 127.0.0.1 --log-level warning` *(fails: jinja2 not installed)*