### PR TITLE
Fix README stray lines and add web setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Minecraft Server Manager
 
- 
-
 ## Features
 
 - Connect to a server via RCON
@@ -12,7 +10,6 @@
 - Send arbitrary commands
 - Tail the server log file
 - Manage the server whitelist
-
 
 Enable RCON in your `server.properties` file:
 
@@ -46,40 +43,24 @@ python minecraft_manager.py --host 127.0.0.1 --password secret --log-file /path/
 
 Note: the restart command simply sends `restart` through RCON. You must have a plugin or script handling server restarts.
 
- l7slgt-codex/corriger-l-erreur--nameerror--main-not-defined
 ## Web Dashboard
 
-This project also includes a small FastAPI application that lets you manage the server from a browser. Install the web dependencies and run Uvicorn:
+This project also includes a small FastAPI application that lets you manage the server from a browser.
 
-## Web Interface
+### Setup
 
-p0df9a-codex/corriger-l-erreur--nameerror--main-not-defined
-This repository also provides a small FastAPI application offering a web-based dashboard.
-Install the extra dependencies and launch the server with:
-main
+Install the web dependencies:
 
 ```bash
 pip install fastapi uvicorn jinja2
-uvicorn web_manager:app --host 0.0.0.0 --port 8000
 ```
 
-l7slgt-codex/corriger-l-erreur--nameerror--main-not-defined
-Open `http://localhost:8000` to configure the connection to your Minecraft server. Once configured you can send commands, broadcast messages, ban or whitelist players, restart the server and view the latest log lines.
-
-Once running, open your browser to the chosen host and port. The interface allows
-you to send commands, broadcast messages, ban players, manage the whitelist and
-view recent logs directly from your browser.
-
-
-Run the FastAPI app with `uvicorn`:
+Start the dashboard with:
 
 ```bash
 uvicorn web_manager:app --host 0.0.0.0 --port 8000
 ```
 
-On first launch you will be asked for the server directory and RCON details.
-The dashboard then allows you to send commands, broadcast messages, ban or
-whitelist players, restart the server and view recent log entries.
-main
-main
+Open `http://localhost:8000` to configure the connection to your Minecraft server. Once configured you can send commands, broadcast messages, ban or whitelist players, restart the server and view the latest log lines.
 
+On first launch you will be asked for the server directory and RCON details. The dashboard then allows you to manage the server entirely from your browser.


### PR DESCRIPTION
## Summary
- clean up README
- document running the FastAPI dashboard

## Testing
- `python -m py_compile minecraft_manager.py web_manager.py`