### PR TITLE
Add authentication to web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ Start the dashboard with:
 uvicorn web_manager:app --host 0.0.0.0 --port 8000
 ```
 
-Open `http://localhost:8000` to configure the connection to your Minecraft server. Once configured you can send commands, broadcast messages, ban or whitelist players, restart the server and view the latest log lines.
+Open `http://localhost:8000` to configure the connection to your Minecraft server. During setup you will be asked for an admin password used to access the dashboard. Once configured you can log in and send commands, broadcast messages, ban or whitelist players, restart the server and view the latest log lines.
 
-On first launch you will be asked for the server directory and RCON details. The dashboard then allows you to manage the server entirely from your browser.
+On first launch you will be asked for the server directory, RCON details and an admin password. The password is stored as a SHA256 hash in `server_config.json` and is required to log in. The dashboard then allows you to manage the server entirely from your browser.

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,6 +8,11 @@
 <body>
     <div class="container-box">
         <h1>Minecraft Manager</h1>
+        {% if request.cookies.session %}
+        <p><a href="/logout">Logout</a></p>
+        {% else %}
+        <p><a href="/login">Login</a></p>
+        {% endif %}
         {% block content %}{% endblock %}
     </div>
 </body>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>Login</h2>
+{% if error %}<p class="text-danger">{{ error }}</p>{% endif %}
+<form method="post">
+    <input type="password" name="password" placeholder="Password" required class="form-control mb-2">
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -14,6 +14,8 @@
     <input type="number" name="port" id="port" value="25575" required class="form-control mb-2">
     <label for="password" class="form-label">RCON Password:</label>
     <input type="password" name="password" id="password" required class="form-control mb-2">
+    <label for="admin_password" class="form-label">Admin Password:</label>
+    <input type="password" name="admin_password" id="admin_password" required class="form-control mb-2">
     <button type="submit" class="btn btn-primary mt-2">Save</button>
 </form>
 {% endblock %}

--- a/web_manager.py
+++ b/web_manager.py
@@ -1,9 +1,11 @@
 import json
 import os
+import hmac
+import hashlib
 from typing import Optional
 
 import asyncio
-from fastapi import FastAPI, Form, Request, WebSocket
+from fastapi import FastAPI, Form, Request, WebSocket, Depends, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
@@ -16,6 +18,9 @@ app = FastAPI(title="Minecraft Web Manager")
 templates = Jinja2Templates(directory="templates")
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
 
 def load_config() -> Optional[dict]:
     if os.path.exists(CONFIG_PATH):
@@ -26,6 +31,19 @@ def load_config() -> Optional[dict]:
 def save_config(data: dict) -> None:
     with open(CONFIG_PATH, "w", encoding="utf8") as f:
         json.dump(data, f, indent=2)
+
+
+def is_authenticated(request: Request) -> bool:
+    cfg = load_config()
+    if not cfg:
+        return False
+    token = request.cookies.get("session")
+    return bool(token and hmac.compare_digest(token, cfg.get("admin_password_hash", "")))
+
+
+def require_auth(request: Request):
+    if not is_authenticated(request):
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
 def get_client() -> RCONClient:
     cfg = load_config()
@@ -86,6 +104,30 @@ def render_dashboard(request: Request, result: Optional[str] = None) -> HTMLResp
 async def index(request: Request):
     return render_dashboard(request)
 
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.post("/login")
+async def login(request: Request, password: str = Form(...)):
+    cfg = load_config()
+    if not cfg:
+        return RedirectResponse("/", status_code=302)
+    if hmac.compare_digest(hash_password(password), cfg.get("admin_password_hash", "")):
+        response = RedirectResponse("/", status_code=302)
+        response.set_cookie("session", cfg.get("admin_password_hash"), httponly=True)
+        return response
+    return templates.TemplateResponse("login.html", {"request": request, "error": "Invalid password"})
+
+
+@app.get("/logout")
+async def logout():
+    response = RedirectResponse("/login", status_code=302)
+    response.delete_cookie("session")
+    return response
+
 @app.post("/setup")
 async def setup(
     request: Request,
@@ -93,11 +135,18 @@ async def setup(
     host: str = Form(...),
     port: int = Form(...),
     password: str = Form(...),
+    admin_password: str = Form(...),
 ):
-    save_config({"path": server_dir, "host": host, "port": port, "password": password})
+    save_config({
+        "path": server_dir,
+        "host": host,
+        "port": port,
+        "password": password,
+        "admin_password_hash": hash_password(admin_password),
+    })
     return RedirectResponse("/", status_code=302)
 
-@app.post("/command", response_class=HTMLResponse)
+@app.post("/command", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def command(request: Request, cmd: str = Form(...)):
     client = get_client()
     try:
@@ -106,7 +155,7 @@ async def command(request: Request, cmd: str = Form(...)):
         client.close()
     return render_dashboard(request, result)
 
-@app.post("/broadcast", response_class=HTMLResponse)
+@app.post("/broadcast", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def broadcast(request: Request, message: str = Form(...)):
     client = get_client()
     try:
@@ -115,7 +164,7 @@ async def broadcast(request: Request, message: str = Form(...)):
         client.close()
     return render_dashboard(request, result)
 
-@app.post("/ban", response_class=HTMLResponse)
+@app.post("/ban", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def ban(request: Request, player: str = Form(...)):
     client = get_client()
     try:
@@ -124,7 +173,7 @@ async def ban(request: Request, player: str = Form(...)):
         client.close()
     return render_dashboard(request, result)
 
-@app.post("/whitelist", response_class=HTMLResponse)
+@app.post("/whitelist", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def whitelist(request: Request, player: str = Form(...), action: str = Form("add")):
     client = get_client()
     try:
@@ -133,7 +182,7 @@ async def whitelist(request: Request, player: str = Form(...), action: str = For
         client.close()
     return render_dashboard(request, result)
 
-@app.post("/restart", response_class=HTMLResponse)
+@app.post("/restart", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def restart(request: Request):
     client = get_client()
     try:
@@ -142,7 +191,7 @@ async def restart(request: Request):
         client.close()
     return render_dashboard(request, result)
 
-@app.get("/logs", response_class=HTMLResponse)
+@app.get("/logs", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def logs(request: Request, lines: int = 50):
     cfg = load_config()
     if not cfg:
@@ -160,6 +209,10 @@ async def websocket_logs(websocket: WebSocket):
     await websocket.accept()
     cfg = load_config()
     if not cfg:
+        await websocket.close()
+        return
+    token = websocket.cookies.get("session")
+    if not token or not hmac.compare_digest(token, cfg.get("admin_password_hash", "")):
         await websocket.close()
         return
     log_path = os.path.join(cfg["path"], "logs", "latest.log")


### PR DESCRIPTION
## Summary
- require an admin password during setup
- add login/logout flow using a simple cookie-based session
- protect command and log endpoints behind authentication
- show login state in the template
- remove unused constant

## Testing
- `pytest -q`
- `python -m py_compile web_manager.py`
- `uvicorn web_manager:app --host 127.0.0.1 --port 8000` *(fails: jinja2 missing)*